### PR TITLE
Scrolling-down-grid-view-gives-client-side-exception

### DIFF
--- a/components/AtlasController/index.js
+++ b/components/AtlasController/index.js
@@ -163,8 +163,11 @@ const AtlasController = ({ width, height }) => {
         opacity={opacity}
         highlightedLayer={highlightedLayer}
         bearing={heading}
-        isDrawing={drawSearch}
+        isDrawing={drawSearch === 'box'}
         drawBoxHandler={e => dispatch(['SET_DRAW_SEARCH_COORDS', flatten(e)])}
+        clickHandler={e => {
+          if (drawSearch === 'click') dispatch(['SET_DRAW_SEARCH_COORDS', e]);
+        }}
         hoverHandler={e => {
           if (e.features.length) {
             setProbePosition(e.center);

--- a/components/ImageGrid/index.js
+++ b/components/ImageGrid/index.js
@@ -16,13 +16,13 @@ const ImageGrid = ({ width, height, activeImages }) => {
 
   const Grid = ({ rowIndex, columnIndex, style }) => {
     const index = rowIndex * 3 + columnIndex;
-    const { title, thumbnail, ssid } = activeImages[index];
+    const image = activeImages[index];
     return (
       <div style={style}>
-        <ImageLink ssid={ssid}>
-          <Tooltip label={title} hasArrow>
+        <ImageLink ssid={image.ssid}>
+          <Tooltip label={image.title || 'Untitled'} hasArrow>
             <Box pos="relative" w={`${gridWidth - 40}px`} h="150px" mx="20px" userSelect="none">
-              {thumbnail && <Image src={thumbnail} layout="fill" objectFit="contain" />}
+              {image.thumbnail && <Image src={image.thumbnail} layout="fill" objectFit="contain" />}
             </Box>
           </Tooltip>
         </ImageLink>

--- a/components/ImageGrid/index.js
+++ b/components/ImageGrid/index.js
@@ -15,8 +15,12 @@ const ImageGrid = ({ width, height, activeImages }) => {
   const gridWidth = (width - 40) / numColumns;
 
   const Grid = ({ rowIndex, columnIndex, style }) => {
-    const index = rowIndex * 3 + columnIndex;
+    const index = rowIndex * numColumns + columnIndex;
     const image = activeImages[index];
+    if (!image) {
+      return null;
+    }
+
     return (
       <div style={style}>
         <ImageLink ssid={image.ssid}>

--- a/components/MapSearch/index.js
+++ b/components/MapSearch/index.js
@@ -4,17 +4,18 @@ import axios from 'axios';
 import { useRouter } from 'next/router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeft } from '@fortawesome/pro-light-svg-icons';
-import { faSearch, faVectorSquare } from '@fortawesome/pro-regular-svg-icons';
+import { faSearch, faVectorSquare, faBullseyePointer } from '@fortawesome/pro-regular-svg-icons';
 import {
   InputGroup,
   Input,
   InputLeftElement,
+  Stack,
   HStack,
   Flex,
   Spinner,
   Heading,
   IconButton,
-  Tooltip,
+  Button,
 } from '@chakra-ui/react';
 
 import { useImages } from '../../providers/ImageContext';
@@ -30,6 +31,7 @@ const MapSearch = ({ handler }) => {
   const [searchResults, setSearchResults] = useState(null);
   const [searchActive, setSearchActive] = useState(false);
   const [drawToggle, setDrawToggle] = useState(drawSearch);
+  const [clickSearch, setClickSearch] = useState(true);
 
   useDebouncedEffect(
     () => {
@@ -57,15 +59,19 @@ const MapSearch = ({ handler }) => {
   useEffect(() => {
     setSearchActive(Boolean(string));
     setSearchResults(null);
-    dispatch(['SET_DRAW_SEARCH', false]);
+    if (string) {
+      setDrawToggle(false);
+    }
   }, [string]);
 
   useEffect(() => {
-    dispatch(['SET_DRAW_SEARCH', drawToggle]);
-    if (!drawToggle) {
-      setSearchResults(null);
+    const searchType = clickSearch ? 'click' : 'box';
+    dispatch(['SET_DRAW_SEARCH', drawToggle ? searchType : null]);
+    setSearchResults(null);
+    if (drawToggle) {
+      setString('');
     }
-  }, [drawToggle]);
+  }, [drawToggle, clickSearch]);
 
   useEffect(() => handler(searchActive), [searchActive]);
 
@@ -95,38 +101,60 @@ const MapSearch = ({ handler }) => {
             _focus={{ border: 'none' }}
           />
         </InputGroup>
-        <Tooltip hasArrow label={translations.searchPlace[locale]}>
-          <IconButton
-            variant={drawSearch ? null : 'outline'}
-            colorScheme="blackAlpha"
-            color="black"
-            border="none"
-            icon={<FontAwesomeIcon icon={faVectorSquare} />}
-            onClick={() => setDrawToggle(!drawToggle)}
-          />
-        </Tooltip>
+        <IconButton
+          variant={drawSearch ? null : 'outline'}
+          colorScheme="blackAlpha"
+          color="black"
+          border="none"
+          icon={<FontAwesomeIcon icon={faBullseyePointer} />}
+          onClick={() => setDrawToggle(!drawToggle)}
+        />
       </HStack>
       {searchActive && !searchResults && (
         <Flex alignItems="center" justifyContent="center" mt={100}>
           <Spinner size="xl" />
         </Flex>
       )}
-      {searchResults && searchResults.length > 0 && <SearchResults results={searchResults} />}
       {searchActive && searchResults && searchResults.length === 0 && (
         <Heading size="sm" textAlign="center" mt={30} fontSize={18} lineHeight={1.5} px={2}>
           {`${translations.noResults[locale]} "${string}" ${year}. ${translations.tryAgain[locale]}.`}
         </Heading>
       )}
-      {drawSearch && !searchResults && (
-        <Heading size="sm" textAlign="center" mt={30} fontSize={18} lineHeight={1.5} px={2}>
-          Click and drag on the map to draw a search area to identify features.
-        </Heading>
+      {drawSearch && (
+        <>
+          <Stack mt={2}>
+            <Button
+              size="sm"
+              color="black"
+              leftIcon={<FontAwesomeIcon icon={faBullseyePointer} />}
+              isActive={clickSearch}
+              onClick={() => setClickSearch(true)}
+            >
+              Search by click
+            </Button>
+            <Button
+              size="sm"
+              color="black"
+              leftIcon={<FontAwesomeIcon icon={faVectorSquare} />}
+              isActive={!clickSearch}
+              onClick={() => setClickSearch(false)}
+            >
+              Search by box
+            </Button>
+          </Stack>
+          {!searchResults && (
+            <Heading size="sm" textAlign="center" mt={30} fontSize={18} lineHeight={1.5} px={2}>
+              Click and drag on the map to draw a search area to identify features.
+            </Heading>
+          )}
+        </>
       )}
       {drawSearch && searchResults && searchResults.length === 0 && (
         <Heading size="sm" textAlign="center" mt={30} fontSize={18} lineHeight={1.5} px={2}>
           {`${translations.noResults[locale]} ${year}. ${translations.tryAgain[locale]}.`}
         </Heading>
       )}
+      {searchResults && searchResults.length > 0 && <SearchResults results={searchResults} />}
     </>
   );
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/pro-regular-svg-icons": "^5.15.3",
     "@fortawesome/pro-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "@imaginerio/diachronic-atlas": "^0.8.1",
+    "@imaginerio/diachronic-atlas": "^0.9.1",
     "axios": "^0.19.2",
     "framer-motion": "^2.9.5",
     "html-react-parser": "^0.14.2",

--- a/providers/ImageContext.js
+++ b/providers/ImageContext.js
@@ -60,7 +60,7 @@ const initialState = {
   highlightedLayer: null,
   highlightedFeature: null,
   yearDragging: false,
-  drawSearch: false,
+  drawSearch: null,
   drawSearchCoords: null,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,10 +984,10 @@
   resolved "https://registry.yarnpkg.com/@iiif/vocabulary/-/vocabulary-1.0.19.tgz#c735577bdcbafcb988471391b9e39d772662de62"
   integrity sha512-5XjrB81bVcu80YcYz5Lxcvvio+PJljiZt3pNW8ACbL3OoL+8QoCJ/dwivdYEcoyEck2I8cEMgAZYEOuEZq+fgg==
 
-"@imaginerio/diachronic-atlas@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@imaginerio/diachronic-atlas/-/diachronic-atlas-0.8.1.tgz#b0686c35b7de977e7ed135877f6dd58c393dd185"
-  integrity sha512-DK+NKHReynhw9C9eCJAF6Gvg5yalFaSxQChqATYJiX760ei6bbDnvwOWs6oy2yZzufnOyrUQ7P5r8vbALng/Mw==
+"@imaginerio/diachronic-atlas@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@imaginerio/diachronic-atlas/-/diachronic-atlas-0.9.1.tgz#6a9f39555f835b4c573473b09fe0e87ec6080cef"
+  integrity sha512-is/4KtnNqeOjqZcZmdC+8OV6AK8U7bC7suGHaXoiaHVrEavNC4AlF9cKrYG9oVw/L1Kwzt0YjLzHfUJAomyLRA==
   dependencies:
     "@turf/bbox" "^6.3.0"
     "@turf/bbox-polygon" "^6.5.0"


### PR DESCRIPTION
Changes how the active image properties are destructured to avoid exception and add 'Untitled' to images without a title.

Fixes #98