### PR TITLE
feat(build): send the search API rate-limit bypass token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ NEXT_PUBLIC_SEARCH_API=http://localhost:5000
 # (getStaticProps / getStaticPaths). Must match the token set on the search API.
 # Deliberately NOT NEXT_PUBLIC_ — it stays on the build server and is never
 # bundled into the browser. Leave unset for local builds.
-SEARCH_API_BYPASS_TOKEN=
+RATE_LIMIT_BYPASS_TOKEN=
 NEXT_PUBLIC_RASTER_URL=https://imaginerio-rasters.s3.us-east-1.amazonaws.com
 NEXT_PUBLIC_PAGE_URL=https://forum.imaginerio.org/t/
 NEXT_PUBLIC_PAGE_API=xxxxxxxxx

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # NEXT_PUBLIC_SEARCH_API=http://localhost:5000
 NEXT_PUBLIC_HOST=https://www.imaginerio.org
 NEXT_PUBLIC_SEARCH_API=http://localhost:5000
+# Lets the static build skip the search API's per-IP rate limit. Sent as the
+# `x-ratelimit-bypass` header, and only from build-time data fetching
+# (getStaticProps / getStaticPaths). Must match the token set on the search API.
+# Deliberately NOT NEXT_PUBLIC_ — it stays on the build server and is never
+# bundled into the browser. Leave unset for local builds.
+SEARCH_API_BYPASS_TOKEN=
 NEXT_PUBLIC_RASTER_URL=https://imaginerio-rasters.s3.us-east-1.amazonaws.com
 NEXT_PUBLIC_PAGE_URL=https://forum.imaginerio.org/t/
 NEXT_PUBLIC_PAGE_API=xxxxxxxxx

--- a/pages/[locale]/iconography/[collection]/[id].js
+++ b/pages/[locale]/iconography/[collection]/[id].js
@@ -28,6 +28,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import Footer from '../../../../components/Footer';
 import { findByLabel } from '../../../../utils/iiif';
 import config from '../../../../utils/config';
+import searchBuildHeaders from '../../../../utils/searchApi';
 import pages from '../../../../assets/config/pages';
 import useWindowDimensions from '../../../../utils/useWindowDimensions';
 import { useLocale } from '../../../../hooks/useLocale';
@@ -198,7 +199,9 @@ export async function getStaticPaths() {
   let paths = [];
   const getCollection = collection =>
     axios
-      .get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents?visual=${collection}`)
+      .get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents?visual=${collection}`, {
+        headers: searchBuildHeaders,
+      })
       .then(({ data }) => {
         paths = [
           ...paths,
@@ -232,7 +235,8 @@ export async function getStaticProps({ params }) {
   const lang = locale === 'pt' ? 'pt-BR' : 'en';
   try {
     let { data: metadata } = await axios.get(
-      `${process.env.NEXT_PUBLIC_SEARCH_API}/metadata/${params.id}?lang=${lang}`
+      `${process.env.NEXT_PUBLIC_SEARCH_API}/metadata/${params.id}?lang=${lang}`,
+      { headers: searchBuildHeaders }
     );
 
     const attributes = process.env.NEXT_PUBLIC_ATTR_ORDER.split(',');

--- a/pages/[locale]/iconography/[collection]/index.js
+++ b/pages/[locale]/iconography/[collection]/index.js
@@ -11,6 +11,7 @@ import ImageSearch from '../../../../components/ImageSearch';
 import ViewButtons from '../../../../components/ViewButtons';
 import ImageSort from '../../../../components/ImageSort';
 import ImageViewer from '../../../../components/ImageViewer';
+import searchBuildHeaders from '../../../../utils/searchApi';
 
 import { useImages } from '../../../../providers/ImageContext';
 import useWindowDimensions from '../../../../utils/useWindowDimensions';
@@ -69,7 +70,8 @@ export async function getStaticProps({ params }) {
   const {
     data: [{ Documents }],
   } = await axios.get(
-    `${process.env.NEXT_PUBLIC_SEARCH_API}/documents?visual=${params.collection}`
+    `${process.env.NEXT_PUBLIC_SEARCH_API}/documents?visual=${params.collection}`,
+    { headers: searchBuildHeaders }
   );
   const images = Documents.map(d => ({ ...d, collection: params.collection }));
   return { props: { images, ...params } };

--- a/pages/[locale]/iconography/index.js
+++ b/pages/[locale]/iconography/index.js
@@ -10,6 +10,7 @@ import Header from '../../../components/Header';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import Footer from '../../../components/Footer';
 import { supportedLocales, useLocale } from '../../../hooks/useLocale';
+import searchBuildHeaders from '../../../utils/searchApi';
 
 const Iconography = ({ collections }) => {
   const { locale } = useLocale();
@@ -63,7 +64,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps() {
   let collections = await axios
-    .get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents`)
+    .get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents`, { headers: searchBuildHeaders })
     .then(({ data }) =>
       Promise.all(
         data.map(d =>

--- a/pages/[locale]/map/index.js
+++ b/pages/[locale]/map/index.js
@@ -12,6 +12,7 @@ import ImageController from '../../../components/ImageController';
 
 import { useImages } from '../../../providers/ImageContext';
 import useWindowDimensions from '../../../utils/useWindowDimensions';
+import searchBuildHeaders from '../../../utils/searchApi';
 import { supportedLocales, useLocale } from '../../../hooks/useLocale';
 
 const AtlasController = dynamic(() => import('../../../components/AtlasController'), {
@@ -121,7 +122,9 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents`);
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_SEARCH_API}/documents`, {
+    headers: searchBuildHeaders,
+  });
   const images = data.reduce(
     (memo, d) => [
       ...memo,

--- a/utils/searchApi.js
+++ b/utils/searchApi.js
@@ -1,0 +1,14 @@
+// Requests fired during the static build (getStaticProps / getStaticPaths) fan
+// out fast enough to trip the search API's per-IP rate limit, so a full build
+// fails with 429s. When SEARCH_API_BYPASS_TOKEN is set we send it as the
+// `x-ratelimit-bypass` header and the API lets the build through.
+//
+// The token is intentionally NOT prefixed with NEXT_PUBLIC_, so it stays on the
+// build server and is never bundled into client code. Only spread these headers
+// into build-time data fetching — never into components or SWR fetchers, or the
+// token would ship to browsers and stop being a secret.
+const token = process.env.SEARCH_API_BYPASS_TOKEN;
+
+const searchBuildHeaders = token ? { 'x-ratelimit-bypass': token } : {};
+
+export default searchBuildHeaders;

--- a/utils/searchApi.js
+++ b/utils/searchApi.js
@@ -1,13 +1,13 @@
 // Requests fired during the static build (getStaticProps / getStaticPaths) fan
 // out fast enough to trip the search API's per-IP rate limit, so a full build
-// fails with 429s. When SEARCH_API_BYPASS_TOKEN is set we send it as the
+// fails with 429s. When RATE_LIMIT_BYPASS_TOKEN is set we send it as the
 // `x-ratelimit-bypass` header and the API lets the build through.
 //
 // The token is intentionally NOT prefixed with NEXT_PUBLIC_, so it stays on the
 // build server and is never bundled into client code. Only spread these headers
 // into build-time data fetching — never into components or SWR fetchers, or the
 // token would ship to browsers and stop being a secret.
-const token = process.env.SEARCH_API_BYPASS_TOKEN;
+const token = process.env.RATE_LIMIT_BYPASS_TOKEN;
 
 const searchBuildHeaders = token ? { 'x-ratelimit-bypass': token } : {};
 


### PR DESCRIPTION
## What & why

A full static build fires hundreds of requests at the search API in under a minute, tripping its per-IP rate limit and failing the build with 429s.

This sends a shared bypass token on **build-time** search API requests so the build is allowed through.

## Changes

- New `utils/searchApi.js` — server-only helper exporting `searchBuildHeaders` (`{ 'x-ratelimit-bypass': token }` when `RATE_LIMIT_BYPASS_TOKEN` is set, else `{}`).
- Attach `{ headers: searchBuildHeaders }` to the 5 build-time search API calls in `getStaticProps` / `getStaticPaths`:
  - `pages/[locale]/iconography/index.js`
  - `pages/[locale]/iconography/[collection]/index.js`
  - `pages/[locale]/iconography/[collection]/[id].js` (paths + props)
  - `pages/[locale]/map/index.js`
- Document `RATE_LIMIT_BYPASS_TOKEN` in `.env.example`.

## Security

The token is **not** `NEXT_PUBLIC_` and is attached per-request (never via `axios.defaults`), so it stays server-side and never reaches browsers. Client-side calls — the `useSWR` fetcher and the `AtlasController` / `MapSearch` / `LegendSwatches` components — are intentionally left unauthenticated.

## Deploy notes

- Set `RATE_LIMIT_BYPASS_TOKEN` on the frontend build environment (Render) to the same value as on the search API (a shared env group keeps the two in sync).
- Requires the paired API PR that honors the header: imaginerio/imaginerioSearch#42 — deploy them together.

Prettier + ESLint clean. I did not run a full `next build` (needs the live API + secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
